### PR TITLE
Update HDO description

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ aux_heater_2 | Binary Sensor | If installed indicates if the second auxillary he
 outside_temp | Sensor | The outside temperature
 requested_temp | Sensor | This is the temperature that the heat pump is requesting, it is calcuated by an unknown algorithm and can go higher than expected. An example here is when heating is initially requested it goes higher than needed then reduces as room temperature is reached.
 dewp_control | Binary Sensor | If Dew Point Control is active
-hdo_on | Binary Sensor | Something to do with High Tarrif Rates, do not know about this indicator
+hdo_on | Binary Sensor | High Tariff Rate active - this remotely controlled signal is used to block the operation of heat pump
 
 #### Domestic Hot Water
 Entity | Type | Description


### PR DESCRIPTION
HDO (abbreviation from Czech "Hromadné Dálkové Ovládání" => Mass Remote Control) is used to block big consumers (like boilers, heaters and heat pumps) in time of high electricity demand. The signal is sent by the grid operator and also signals the high tariff rate.