### PR TITLE
Update to Python 3.12 and Fix Warnings

### DIFF
--- a/custom_components/mastertherm/manifest.json
+++ b/custom_components/mastertherm/manifest.json
@@ -9,7 +9,7 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/shedc/homeassistant-mastertherm/issues",
   "requirements": [
-    "masterthermconnect==2.2.11"
+    "masterthermconnect==2.3.0"
   ],
   "version": "1.1.11"
 }

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -4,4 +4,4 @@ colorlog==6.8.2
 ruff==0.3.0
 chardet==5.2.0
 pytest-homeassistant-custom-component==0.13.107
-masterthermconnect==2.3.0a0
+masterthermconnect==2.3.0


### PR DESCRIPTION
Update to Python 3.12 in line with HASS
Fix Climate Warning